### PR TITLE
Improve menu style

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -96,6 +96,31 @@
                 mainmenu.style.left = '-200px';
             }
         });
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag = evt.target;
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
     </script>
 </body>
 </html>

--- a/about/index.html
+++ b/about/index.html
@@ -24,19 +24,19 @@
         <div style="width: 30px; height: 30px;"></div>
     </section>
     <div class="topbarunderlay">&nbsp;</div>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/contact/index.html
+++ b/contact/index.html
@@ -24,19 +24,19 @@
         <div style="width: 30px; height: 30px;"></div>
     </section>
     <div class="topbarunderlay">&nbsp;</div>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/contact/index.html
+++ b/contact/index.html
@@ -71,6 +71,31 @@
                 mainmenu.style.left = '-200px';
             }
         });
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag = evt.target;
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -157,6 +157,46 @@
         }
 
         window.addEventListener('scroll', scrollHandler);
+
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag;
+
+            if (evt.target.nodeName == 'A') {
+                AnchorTag = evt.target;
+            } else {
+                evt.target.style.opacity = 0;
+                AnchorTag = evt.target.closest('a');
+            }
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+        let projectGridAnchors = document.querySelectorAll('#projects a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
+        
+        projectGridAnchors.forEach(projectGridAnchor => {
+            console.log(projectGridAnchor);
+            projectGridAnchor.addEventListener('click', handleMenuItemClick)
+        });
+
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -23,19 +23,19 @@
         </div>
         <div style="width: 30px; height: 30px;"></div>
     </section>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/projects/chaska/index.html
+++ b/projects/chaska/index.html
@@ -23,19 +23,19 @@
         </div>
         <div style="width: 30px; height: 30px;"></div>
     </section>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/projects/chaska/index.html
+++ b/projects/chaska/index.html
@@ -101,6 +101,31 @@
                 mainmenu.style.left = '-200px';
             }
         });
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag = evt.target;
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
     </script>
 </body>
 </html>

--- a/projects/clyde-hill/index.html
+++ b/projects/clyde-hill/index.html
@@ -24,19 +24,19 @@
         <div style="width: 30px; height: 30px;"></div>
     </section>
     <div class="topbarunderlay">&nbsp;</div>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/projects/clyde-hill/index.html
+++ b/projects/clyde-hill/index.html
@@ -106,6 +106,31 @@
                 mainmenu.style.left = '-200px';
             }
         });
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag = evt.target;
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
     </script>
 </body>
 </html>

--- a/projects/enatai/index.html
+++ b/projects/enatai/index.html
@@ -24,19 +24,19 @@
         <div style="width: 30px; height: 30px;"></div>
     </section>
     <div class="topbarunderlay">&nbsp;</div>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/projects/enatai/index.html
+++ b/projects/enatai/index.html
@@ -116,6 +116,31 @@
                 mainmenu.style.left = '-200px';
             }
         });
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag = evt.target;
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
     </script>
 </body>
 </html>

--- a/projects/glendale/index.html
+++ b/projects/glendale/index.html
@@ -24,19 +24,19 @@
         <div style="width: 30px; height: 30px;"></div>
     </section>
     <div class="topbarunderlay">&nbsp;</div>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/projects/glendale/index.html
+++ b/projects/glendale/index.html
@@ -113,6 +113,31 @@
                 mainmenu.style.left = '-200px';
             }
         });
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag = evt.target;
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
     </script>
 </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -23,19 +23,19 @@
         </div>
         <div style="width: 30px; height: 30px;"></div>
     </section>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/projects/index.html
+++ b/projects/index.html
@@ -130,6 +130,45 @@
                 mainmenu.style.left = '-200px';
             }
         });
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag;
+
+            if (evt.target.nodeName == 'A') {
+                AnchorTag = evt.target;
+            } else {
+                evt.target.style.opacity = 0;
+                AnchorTag = evt.target.closest('a');
+            }
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+        let projectGridAnchors = document.querySelectorAll('#projectsGrid a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
+        
+        projectGridAnchors.forEach(projectGridAnchor => {
+            console.log(projectGridAnchor);
+            projectGridAnchor.addEventListener('click', handleMenuItemClick)
+        });
+
     </script>
 </body>
 </html>

--- a/projects/westfield/index.html
+++ b/projects/westfield/index.html
@@ -24,19 +24,19 @@
         <div style="width: 30px; height: 30px;"></div>
     </section>
     <div class="topbarunderlay">&nbsp;</div>
-    <nav id="mainmenu" class="p-1">
+    <nav id="mainmenu"  style="left: -200px">
         <ul>
-            <li class="py-1/2">
-                <a href="/">Home</a>
+            <li>
+                <a class="p-1" href="/">Home</a>
             </li>
-            <li class="py-1/2">
-                <a href="/projects">Projects</a>
+            <li>
+                <a class="p-1" href="/projects">Projects</a>
             </li>
-            <li class="py-1/2">
-                <a href="/about">About</a>
+            <li>
+                <a class="p-1" href="/about">About</a>
             </li>
-            <li class="py-1/2">
-                <a href="/contact">Contact</a>
+            <li>
+                <a class="p-1" href="/contact">Contact</a>
             </li>
         </ul>
     </nav>

--- a/projects/westfield/index.html
+++ b/projects/westfield/index.html
@@ -101,6 +101,31 @@
                 mainmenu.style.left = '-200px';
             }
         });
+
+        // There is an issue with the bfcache that causes the menu state and the project hover state to persist
+        // when the user clicks the back button in their browser. I want it to go back to the original state.
+
+        // Since the user is navigating away from the page, I can try to add an event handler to anchors that
+        // will collapse the menu and ensure the hover state returns on click. I might have to prevent default
+        // and manually follow the location using js. We'll see...
+
+        function handleMenuItemClick(evt) {
+            evt.preventDefault();
+
+            // Get the menu and collapse it.
+            let mainmenu = document.getElementById('mainmenu');
+            mainmenu.style.left = '-200px';
+
+            let AnchorTag = evt.target;
+
+            window.location = AnchorTag.href;
+        }
+
+        let menuAnchors = document.querySelectorAll('#mainmenu a');
+
+        menuAnchors.forEach(menuAnchor => {
+            menuAnchor.addEventListener('click', handleMenuItemClick)
+        });
     </script>
 </body>
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -5,7 +5,6 @@ html, body, * {
 }
 
 h1, h2, h3, h4, h5, h6, p, li {
-    /* font-family: "Montserrat", sans-serif; */
     font-family: "Tahoma", sans-serif;
     font-optical-sizing: auto;
     font-weight: 300;

--- a/styles/main.css
+++ b/styles/main.css
@@ -79,7 +79,7 @@ p, li {
     top: 0;
     width: 100vw;
     display: flex;
-    z-index: 999;
+    z-index: 9999;
     justify-content: space-between;
 }
 
@@ -130,7 +130,7 @@ nav {
     height: 100vh;
     background-color: #FFF;
     color: #000;
-    z-index: 999;
+    z-index: 9999;
     top:52px;
     left: -100px;
     transition: left .5s;

--- a/styles/main.css
+++ b/styles/main.css
@@ -150,8 +150,6 @@ nav ul a {
     display: flex;
     flex-direction: column;
     align-items: center;
-    /* width: calc(100vw - 1em); */
-    /* width: 100vw; */
 }
 
 .projectImages {
@@ -172,7 +170,6 @@ nav ul a {
 
 .projectImages img{
     width: 100%;
-    /* max-width: 1200px; */
     margin: auto;
 }
 
@@ -226,12 +223,10 @@ nav ul a {
     max-width: 350px;
     width: 50%;
     height: 50%;
-    /* fill: #55a9de; */
     fill: white;
 }
 
 #projectsGrid {
-    /* max-width: 1300px; */
     padding: 6rem;
     width: 100%;
 }
@@ -268,8 +263,6 @@ nav ul a {
 }
 
 .contact {
-    /* width: 95vw; */
-    /* height: 90vh; */
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -317,7 +310,6 @@ nav ul a {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     gap: 8rem;
-    /* width: 100vw; */
 }
 
 .max-960 { 

--- a/styles/main.css
+++ b/styles/main.css
@@ -132,7 +132,7 @@ nav {
     background-color: #FFF;
     color: #000;
     z-index: 999;
-    top:55px;
+    top:52px;
     left: -100px;
     transition: left .5s;
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -135,6 +135,7 @@ nav {
     top:52px;
     left: -100px;
     transition: left .5s;
+    box-shadow: 0 0 4px 4px rgba(0,0,0,0.2);
 }
 
 nav ul {

--- a/styles/main.css
+++ b/styles/main.css
@@ -144,6 +144,7 @@ nav ul {
 
 nav ul a {
     text-decoration: none;
+    color: #000;
 }
 
 #main {

--- a/styles/main.css
+++ b/styles/main.css
@@ -141,9 +141,15 @@ nav ul {
     list-style: none;
 }
 
+nav ul li {
+    border-bottom: 1px solid #CCC;
+}
+
 nav ul a {
     text-decoration: none;
     color: #000;
+    display: inline-block;
+    width: 100%;
 }
 
 #main {


### PR DESCRIPTION
This PR fixes z index issues in the main menu, some padding issues in the main menu and also adds some javascript to return the menu and the project images to their initialized state when an anchor is clicked that leads to another page. This fixes an issue where the browser is caching the last visited page including its state (clicking the back button in the browser resulted in the menu being expanded and the project tiles having an active hover state).